### PR TITLE
Fix when web-crawling the GOT Character title names.

### DIFF
--- a/lib/gotfaker/character.rb
+++ b/lib/gotfaker/character.rb
@@ -4,7 +4,7 @@ require 'open-uri'
 module GOTFaker
   class Character
     noko = Nokogiri::HTML(open("http://awoiaf.westeros.org/index.php/List_of_characters"))
-    @names = noko.search('#mw-content-text > ul >li> a:first-child').map{|name| name.inner_text}
+    @names = noko.search('#mw-content-text ul li a:first-child').map{|name| name.inner_text}.uniq
 
 
     def self.random_name


### PR DESCRIPTION
Edit the HTML elements criteria to bring the title names of all GOT Characters. Also removed the duplicated ones.